### PR TITLE
Asset precompile broken (need group: :all)

### DIFF
--- a/lib/rails_admin_nestable/engine.rb
+++ b/lib/rails_admin_nestable/engine.rb
@@ -1,7 +1,7 @@
 module RailsAdminNestable
   class Engine < ::Rails::Engine
 
-    initializer "RailsAdminNestable precompile hook" do |app|
+    initializer "RailsAdminNestable precompile hook", group: :all do |app|
       app.config.assets.precompile += %w(rails_admin/rails_admin_nestable.js rails_admin/jquery.nestable.js rails_admin/rails_admin_nestable.css)
     end
 


### PR DESCRIPTION
I get this error:

```
ActionView::Template::Error (rails_admin/rails_admin_nestable.css isn't precompiled):
     5:         = nested_tree_nodes @tree_nodes
     6: 
     7: 
     8: = stylesheet_link_tag 'rails_admin/rails_admin_nestable'
     9: = javascript_include_tag 'rails_admin/jquery.nestable'
     10: = javascript_include_tag 'rails_admin/rails_admin_nestable'
   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/sprockets/helpers/rails_helper.rb:142:in `digest_for'
   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/sprockets/helpers/rails_helper.rb:151:in `rewrite_asset_path'
   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/action_view/asset_paths.rb:27:in `compute_public_path'
   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/sprockets/helpers/rails_helper.rb:56:in `asset_path'
   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/sprockets/helpers/rails_helper.rb:49:in `block in stylesheet_link_tag'
   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/sprockets/helpers/rails_helper.rb:43:in `collect'
   vendor/bundle/ruby/2.0.0/gems/actionpack-3.2.13/lib/sprockets/helpers/rails_helper.rb:43:in `stylesheet_link_tag'
   vendor/bundle/ruby/2.0.0/gems/rails_admin_nestable-0.1.4/app/views/rails_admin/main/nestable.html.haml:8:in `_vendor_bundle_ruby_______gems_rails_admin_nestable_______app_views_rails_admin_main_nestable_html_haml__4520128846218037385_69959166418540'
.......
.......
```

RailsAdmin includes a `group: :assets` entry in the initializer block to handle this. https://github.com/sferik/rails_admin/blob/master/lib/rails_admin/engine.rb#L19

This used to be there in RailsAdminNestable, but was taken out: https://github.com/dalpo/rails_admin_nestable/commit/7997179325eed7805980d88fd4643618f09c6277#L1L4

This pull request adds it back in.
