### PR TITLE
Add options :scope for nestable_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ To use this configuration, you need a position field
 The `nestable_list` methods supports the following options:
   * `position_field`: (symbol) default `:position`
   * `enable_callback`: (boolean) default => `false`
+  * `scope`: (symbol|proc) default `nil`, must be a `ActiveRecord::Relation` object of models
 
 In your `config/initializers/rails_admin.rb` initializer:
 ```ruby

--- a/lib/rails_admin_nestable/configuration.rb
+++ b/lib/rails_admin_nestable/configuration.rb
@@ -2,7 +2,7 @@ module RailsAdminNestable
   class Configuration
 
     TREE_DEFAULT_OPTIONS = { enable_callback: false }
-    LIST_DEFAULT_OPTIONS = { position_field: :position, max_depth: 1, enable_callback: false }
+    LIST_DEFAULT_OPTIONS = { position_field: :position, max_depth: 1, enable_callback: false, scope: nil }
 
     def initialize(abstract_model)
       @abstract_model = abstract_model

--- a/lib/rails_admin_nestable/nestable.rb
+++ b/lib/rails_admin_nestable/nestable.rb
@@ -77,7 +77,17 @@ module RailsAdmin
               end
 
               if @nestable_conf.list?
-                @tree_nodes = @abstract_model.model.order(@nestable_conf.options[:position_field])
+                scope = begin
+                  case @nestable_conf.options[:scope].class.to_s
+                  when 'Proc'
+                    @nestable_conf.options[:scope].call
+                  when 'Symbol'
+                    @abstract_model.model.public_send(@nestable_conf.options[:scope])
+                  else
+                    nil
+                  end
+                end
+                @tree_nodes = @abstract_model.model.order(@nestable_conf.options[:position_field]).merge(scope)
               end
 
               render action: @action.template_name


### PR DESCRIPTION
Hi! Because the `nestable` list is ascending sort by `position_field`, but normally it is null or the default value on database (excepts sorted via `nestable`), and `rails_admin` list is descending sort by primary key. So I have feature plan implementing scope options to help sorting them or whatever.

Example:

``` ruby
# models/list.rb
class List < ActiveRecord::Base
  # ...
  scope :by_default, -> { List.order('id desc') }
  # ...
end

# config/initializers/rails_admin.rb
RailsAdmin.config do |config|
  # ...
  config.model 'List' do
    nestable_list({
      scope: :by_default # or scope: -> { List.order('id desc') }
    })
  end
  # ...
end
```

and on the `nestable` list page have like this SQLs:

``` sql
SELECT * FROM `lists` ORDER BY position, id desc
```
