### PR TITLE
:scope for both nestable_list and nestable_tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The `nestable_tree` methods supports the following options:
   * `position_field`: (symbol) default => `nil`
   * `max_depth`: (integer) default => `nil`
   * `enable_callback`: (boolean) default => `false`
+  * `scope`: (symbol|proc) default => `nil`, must be a `ActiveRecord::Relation` object of models
 
 In your `config/initializers/rails_admin.rb` initializer:
 ```ruby
@@ -73,7 +74,7 @@ To use this configuration, you need a position field
 The `nestable_list` methods supports the following options:
   * `position_field`: (symbol) default `:position`
   * `enable_callback`: (boolean) default => `false`
-  * `scope`: (symbol|proc) default `nil`, must be a `ActiveRecord::Relation` object of models
+  * `scope`: (symbol|proc) default => `nil`, must be a `ActiveRecord::Relation` object of models
 
 In your `config/initializers/rails_admin.rb` initializer:
 ```ruby

--- a/lib/rails_admin_nestable/configuration.rb
+++ b/lib/rails_admin_nestable/configuration.rb
@@ -1,7 +1,7 @@
 module RailsAdminNestable
   class Configuration
 
-    TREE_DEFAULT_OPTIONS = { enable_callback: false }
+    TREE_DEFAULT_OPTIONS = { enable_callback: false, scope: nil }
     LIST_DEFAULT_OPTIONS = { position_field: :position, max_depth: 1, enable_callback: false, scope: nil }
 
     def initialize(abstract_model)

--- a/lib/rails_admin_nestable/nestable.rb
+++ b/lib/rails_admin_nestable/nestable.rb
@@ -72,22 +72,25 @@ module RailsAdmin
 
               render text: message
             else
+              scope = begin
+                case @nestable_conf.options[:scope].class.to_s
+                when 'Proc'
+                  @nestable_conf.options[:scope].call
+                when 'Symbol'
+                  @abstract_model.model.public_send(@nestable_conf.options[:scope])
+                else
+                  nil
+                end
+              end
+
+              query = @abstract_model.model.scoped.merge(scope)
+
               if @nestable_conf.tree?
-                @tree_nodes = @abstract_model.model.arrange(order: @nestable_conf.options[:position_field])
+                @tree_nodes = query.arrange(order: @nestable_conf.options[:position_field])
               end
 
               if @nestable_conf.list?
-                scope = begin
-                  case @nestable_conf.options[:scope].class.to_s
-                  when 'Proc'
-                    @nestable_conf.options[:scope].call
-                  when 'Symbol'
-                    @abstract_model.model.public_send(@nestable_conf.options[:scope])
-                  else
-                    nil
-                  end
-                end
-                @tree_nodes = @abstract_model.model.order(@nestable_conf.options[:position_field]).merge(scope)
+                @tree_nodes = query.order(@nestable_conf.options[:position_field])
               end
 
               render action: @action.template_name


### PR DESCRIPTION
Same changes as https://github.com/dalpo/rails_admin_nestable/pull/20, but also added to nestable_tree.

I needed this to only be able to sort only active items. `scope: -> { List.where(active: true) }`

Props to https://github.com/gokure
