### PR TITLE
Update class to work with Bootstrap 3 (which RA now uses)

### DIFF
--- a/lib/rails_admin_nestable/helper.rb
+++ b/lib/rails_admin_nestable/helper.rb
@@ -19,7 +19,7 @@ module RailsAdminNestable
     end
 
     def action_links(model)
-      content_tag :ul, class: 'inline actions' do
+      content_tag :ul, class: 'inline list-inline' do
         menu_for :member, @abstract_model, model, true
       end
     end


### PR DESCRIPTION
RailsAdmin's latest version upgraded from BS2 to BS3. This change is needed to keep the actions as a horizontal list (otherwise they're a vertical list).