### PR TITLE
Create a new object_label option to customize the object label

### DIFF
--- a/lib/rails_admin_nestable/helper.rb
+++ b/lib/rails_admin_nestable/helper.rb
@@ -8,7 +8,7 @@ module RailsAdminNestable
 
           output = content_tag :div, 'drag', class: 'dd-handle dd3-handle'
           output += content_tag :div, class: 'dd3-content' do
-            content = link_to @model_config.with(object: tree_node).object_label, edit_path(@abstract_model, tree_node.id)
+            content = link_to object_label(tree_node), edit_path(@abstract_model, tree_node.id)
             content += content_tag :div, action_links(tree_node), class: 'pull-right links'
           end
 
@@ -26,6 +26,24 @@ module RailsAdminNestable
 
     def tree_max_depth
       @nestable_conf.options[:max_depth] || 'false'
+    end
+
+    def object_label(tree_node)
+      custom_object_label = @nestable_conf.options[:object_label]
+      return default_object_label(tree_node) unless custom_object_label.present?
+
+      case custom_object_label
+      when Symbol
+        tree_node.public_send(custom_object_label)
+      when proc { custom_object_label.respond_to? :call }
+        custom_object_label.call(tree_node)
+      else
+        fail 'object_label must be a Symbol or a Proc'
+      end
+    end
+
+    def default_object_label(tree_node)
+      @model_config.with(object: tree_node).object_label
     end
   end
 end


### PR DESCRIPTION
Hi Andrea, how are you doing?

I needed the object_label of each list item to be different from the RailsAdmin default object_label.

Reason: the RailsAdmin "list" GET method can show a table with many columns, which may have valuable context and information (specially in complex models). We don't have additional columns in the ordination list; we only have the object label.

So I implemented an object_label option to provide more flexibility in what to show for each item. It works like this:

- You can specify an object_label: a Symbol or a Proc
- If you don't, it fallbacks to the previous implemented method, which uses RailsAdmin object_label.

If you have any issues on this pull request I'll be glad to address them.

Thanks.
