### PR TITLE
Fix a position field bug on the controller when saving an ordination

### DIFF
--- a/lib/rails_admin_nestable/nestable.rb
+++ b/lib/rails_admin_nestable/nestable.rb
@@ -23,7 +23,7 @@ module RailsAdmin
         register_instance_option :controller do
           Proc.new do |klass|
             @nestable_conf = ::RailsAdminNestable::Configuration.new @abstract_model
-            @position_field = @nestable_conf.options[:position_field]
+            @position_field = @nestable_conf.options[:position_field].to_s.split('.').last
             @enable_callback = @nestable_conf.options[:enable_callback]
             @nestable_scope = @nestable_conf.options[:scope]
             @options = @nestable_conf.options


### PR DESCRIPTION
Hi Andrea,

This commit fixes a bug that happens when one tries to use a fully qualified column name for the position column, such as the string "my_table.position".

I needed to use a fully qualified name in my config to avoid ambiguities in the column names, because one of the tables of the query was already referencing a "position" field.

The controller code that saves the list ordination sends a message to the ActiveRecord object, in order to write a number to the position field:

```ruby
model.send("#{@position_field}=".to_sym, (key.to_i + 1))
```

That blows up, because it tries to send a message named "my_table.position=" to the ActiveRecord object, when the actual and correct message is "position=".

I'll be glad to fix any issues.

Thanks.