### PR TITLE
fixed helper method nested_tree_nodes when the subtree is nil

### DIFF
--- a/lib/rails_admin_nestable/helper.rb
+++ b/lib/rails_admin_nestable/helper.rb
@@ -1,6 +1,7 @@
 module RailsAdminNestable
   module Helper
     def nested_tree_nodes(tree_nodes = [])
+      return if tree_nodes.nil?
       tree_nodes.map do |tree_node, sub_tree_nodes|
         li_classes = 'dd-item dd3-item'
 


### PR DESCRIPTION
## Description
- Fixed helper method nested_tree_nodes when the subtree is nil the method crashed