### PR TITLE
fixed helper method nested_tree_nodes when the subtree is nil

### DIFF
--- a/lib/rails_admin_nestable/helper.rb
+++ b/lib/rails_admin_nestable/helper.rb
@@ -1,6 +1,7 @@
 module RailsAdminNestable
   module Helper
     def nested_tree_nodes(tree_nodes = [])
+      return if tree_nodes.nil?
       tree_nodes.map do |tree_node, sub_tree_nodes|
         li_classes = 'dd-item dd3-item'
 


### PR DESCRIPTION
This PR contains a fixed for the issue https://github.com/dalpo/rails_admin_nestable/issues/63

## Description
- In this PR there is a fix for the helper method nested_tree_nodes (lib/rails_admin_nestable/helper.rb)
- The fix consists about to return when the subtree is nil before continuing with the next statements