### PR TITLE
Pass current params into scope proc

### DIFF
--- a/lib/rails_admin_nestable/nestable.rb
+++ b/lib/rails_admin_nestable/nestable.rb
@@ -71,7 +71,7 @@ module RailsAdmin
 
               case @options[:scope].class.to_s
                 when 'Proc'
-                  query.merge!(@options[:scope].call)
+                  query.merge!(@options[:scope].call(params))
                 when 'Symbol'
                   query.merge!(@abstract_model.model.public_send(@options[:scope]))
               end


### PR DESCRIPTION
This is a tiny change that would make the Proc scope option much more useful, as it allows you to do things like:

```
    scope_from_params = Proc.new do |params|
      if [:team_a, :team_b, :team_c, :team_other, :draft].include? params[:scope].to_sym
        Employee.public_send(params[:scope]) 
      else 
        Employee.all
      end
    end

    nestable_list scope: scope_from_params
```

So that you can dynamically control the scoping of the list via links / urls etc.