### PR TITLE
Ability to make sorting with different models

### DIFF
--- a/lib/rails_admin_nestable/helper.rb
+++ b/lib/rails_admin_nestable/helper.rb
@@ -5,11 +5,12 @@ module RailsAdminNestable
       tree_nodes.map do |tree_node, sub_tree_nodes|
         li_classes = 'dd-item dd3-item'
 
-        content_tag :li, class: li_classes, :'data-id' => tree_node.id do
+        content_tag :li, class: li_classes, :'data-id' => tree_node.id, :'data-type' => tree_node.class.name do
 
-          output = content_tag :div, 'drag', class: 'dd-handle dd3-handle'
+          output = content_tag(:div, 'drag', class: 'dd-handle dd3-handle')
+
           output += content_tag :div, class: 'dd3-content' do
-            content = link_to object_label(tree_node), edit_path(@abstract_model, tree_node.id)
+            content = link_to object_label(tree_node), edit_path(RailsAdmin::AbstractModel.new(tree_node.class), tree_node.id)
             content += content_tag :div, action_links(tree_node), class: 'pull-right links'
           end
 

--- a/lib/rails_admin_nestable/nestable.rb
+++ b/lib/rails_admin_nestable/nestable.rb
@@ -32,7 +32,8 @@ module RailsAdmin
             # Methods
             def update_tree(tree_nodes, parent_node = nil)
               tree_nodes.each do |key, value|
-                model = @abstract_model.model.find(value['id'].to_s)
+                type_class = value['type'].constantize rescue @abstract_model.model
+                model = type_class.find(value['id'].to_s)
                 model.parent = parent_node || nil
                 model.send("#{@position_field}=".to_sym, (key.to_i + 1)) if @position_field.present?
                 model.save!(validate: @enable_callback)


### PR DESCRIPTION
Example of usage:

I have two models:
- `CrewingTypeDocument` - sort of categories

```ruby
class CrewingTypeDocument < ApplicationRecord
  # position_field: :position
  
  has_one :parent, -> { none }, class_name: 'CrewingTypeDocument'
  has_many :children, class_name: 'CrewingDocument'

  # ...
end
```

- `CrewingDocument` - sort of items, belongs to categories
```ruby
class CrewingDocument < ApplicationRecord
  # position_field: :position
  
  belongs_to :parent, class_name: "CrewingTypeDocument"
  has_many :children, -> {none}, class_name: 'CrewingDocument'

  class << self
    def arrange(_options)
      CrewingTypeDocument.order(:position).includes(:children).each_with_object({}) do |item, hash|
        hash[item] = item.children.order(:position)
      end
    end
  end
  
end
```

In such configuration you can have sorting tree in `CrewingDocument` model where top level will be `CrewingTypeDocument`, second level - `CrewingDocument`.

WARNING: if you want to sort groups and items in same form, you should use same `position_field` names

RailsAdmin configuration: 
```ruby
RailsAdmin.config do |config|
  config.actions do
    # ...
    nestable
  end

  config.model 'CrewingDocument' do
    # ...
    nestable_tree live_update: :only, position_field: :position
  end
end
```

Example:
1. sorting items:
![image](https://user-images.githubusercontent.com/15129796/223701439-f3f7f9cf-1e03-4ce0-91b6-15cb77df1915.png)
2. sorting groups:
![image](https://user-images.githubusercontent.com/15129796/223701651-d3e04141-25f7-4830-9224-9f6c2f4915c5.png)

